### PR TITLE
feat: 작성자 테이블 분리 및 일정과 연관관계 설정

### DIFF
--- a/src/main/java/com/example/schedulee/controller/ScheduleController.java
+++ b/src/main/java/com/example/schedulee/controller/ScheduleController.java
@@ -37,29 +37,29 @@ public class ScheduleController {
         return new ResponseEntity<>(getAllInfo,HttpStatus.OK);
     }
 
-    // 특정 스케줄 조회
     @GetMapping("/{id}")
-    public ResponseEntity<ScheduleResponseDto> getSchedule(@PathVariable Long id){
-
-        ScheduleResponseDto sc = scheduleService.searchSchedule(id);
-
-        return new ResponseEntity<>(sc, HttpStatus.OK);
+    public ResponseEntity<List<SearchedScheduleDto>> searchSchedule(
+            @PathVariable Long id
+    ){
+        System.out.println("Received ID: " + id);  // ID 값이 제대로 전달 되는지 확인
+        List<SearchedScheduleDto> dto = scheduleService.searchSchedule(id);
+        return new ResponseEntity<>(dto, HttpStatus.OK);
     }
 
     // 스케줄 수정
     @PatchMapping("/{id}")
-    public ResponseEntity<ScheduleResponseDto> editInfo(@RequestBody ScheduleEditRequestDto dto,
+    public ResponseEntity<SearchedScheduleDto> editInfo(@RequestBody ScheduleEditRequestDto dto,
     @PathVariable Long id){
 
-        ScheduleResponseDto editedSchedule = scheduleService.editInfo(dto,id);
+        SearchedScheduleDto editedSchedule = scheduleService.editInfo(dto,id);
         return new ResponseEntity<>(editedSchedule, HttpStatus.OK);
     }
 
     // 스케줄 삭제
     @DeleteMapping("/{id}")
-    public ResponseEntity<String> deleteSchedule(@PathVariable Long id){
+    public ResponseEntity<String> deleteSchedule(@RequestBody ScheduleDeleteRequestDto dto){
 
-        scheduleService.deleteSchedule(id);
+        scheduleService.deleteSchedule(dto);
 
         return ResponseEntity.ok("선택한 스케줄이 삭제되었습니다.");
     }

--- a/src/main/java/com/example/schedulee/controller/WriterController.java
+++ b/src/main/java/com/example/schedulee/controller/WriterController.java
@@ -1,0 +1,32 @@
+package com.example.schedulee.controller;
+
+import com.example.schedulee.dto.SearchedScheduleDto;
+import com.example.schedulee.dto.WriterRegisterRequestDto;
+import com.example.schedulee.dto.WriterResponseDto;
+import com.example.schedulee.service.WriterService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/writer")
+@RequiredArgsConstructor
+@Slf4j
+public class WriterController {
+
+    private final WriterService writerService;
+
+
+    @PostMapping
+    public ResponseEntity<WriterResponseDto> register(
+            @RequestBody WriterRegisterRequestDto dto
+    ){
+        WriterResponseDto registeredWriter = writerService.register(dto);
+        return new ResponseEntity<>(registeredWriter, HttpStatus.CREATED);
+    }
+
+}

--- a/src/main/java/com/example/schedulee/dto/ScheduleAllDto.java
+++ b/src/main/java/com/example/schedulee/dto/ScheduleAllDto.java
@@ -12,7 +12,9 @@ public class ScheduleAllDto {
 
     private String todo;
 
-    private String writer;
+    private String writerId;
+
+    private String writerName;
 
     private LocalDateTime scheduleDate;
 

--- a/src/main/java/com/example/schedulee/dto/ScheduleDeleteRequestDto.java
+++ b/src/main/java/com/example/schedulee/dto/ScheduleDeleteRequestDto.java
@@ -1,0 +1,12 @@
+package com.example.schedulee.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ScheduleDeleteRequestDto {
+    private Long id;
+    private String password;
+}
+

--- a/src/main/java/com/example/schedulee/dto/ScheduleEditRequestDto.java
+++ b/src/main/java/com/example/schedulee/dto/ScheduleEditRequestDto.java
@@ -9,6 +9,6 @@ import lombok.Setter;
 @Setter
 public class ScheduleEditRequestDto {
     String todo;
-    String writer;
+    String writerName;
     String password; // 수정을 하기 위해 필요한 비밀번호
 }

--- a/src/main/java/com/example/schedulee/dto/ScheduleResponseDto.java
+++ b/src/main/java/com/example/schedulee/dto/ScheduleResponseDto.java
@@ -16,7 +16,7 @@ import java.time.LocalDateTime;
 public class ScheduleResponseDto {
     private Long scheduleId;
     private String todo;
-    private String writer;
+    private String writerId;
     private LocalDateTime createdAt;
     private LocalDateTime modifiedAt;
     private LocalDateTime scheduleDate;
@@ -24,7 +24,7 @@ public class ScheduleResponseDto {
     public ScheduleResponseDto(Schedule schedule) {
         this.scheduleId = schedule.getScheduleId();
         this.todo = schedule.getTodo();
-        this.writer = schedule.getWriter();
+        this.writerId = schedule.getWriterId();
         this.createdAt = schedule.getCreatedAt();
         this.modifiedAt = schedule.getModifiedAt();
         this.scheduleDate = schedule.getScheduleDate();

--- a/src/main/java/com/example/schedulee/dto/SearchedScheduleDto.java
+++ b/src/main/java/com/example/schedulee/dto/SearchedScheduleDto.java
@@ -7,13 +7,15 @@ import lombok.Setter;
 import java.time.LocalDateTime;
 
 @Getter
-@AllArgsConstructor
 @Setter
-public class ScheduleRequestDto {
+@AllArgsConstructor
+public class SearchedScheduleDto {
+    private Long scheduleId;
+    private Long writerId;
+    private String writerName;
+    private String writerEmail;
     private String todo;
-    private String writerId;
+    private LocalDateTime scheduleDate;
     private LocalDateTime createdAt;
     private LocalDateTime modifiedAt;
-    private String password;
-    private LocalDateTime scheduleDate;
 }

--- a/src/main/java/com/example/schedulee/dto/WriterRegisterRequestDto.java
+++ b/src/main/java/com/example/schedulee/dto/WriterRegisterRequestDto.java
@@ -4,13 +4,14 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.Setter;
 
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 @Getter
-@Setter
 @AllArgsConstructor
-public class ScheduleRequestAllDto {
-    private String writerName;
-    private LocalDate modifiedAt;
+@Setter
+public class WriterRegisterRequestDto {
+    private String email;
+    private String name;
+    private LocalDateTime createdAt;
+    private LocalDateTime modifiedAt;
 }

--- a/src/main/java/com/example/schedulee/dto/WriterResponseDto.java
+++ b/src/main/java/com/example/schedulee/dto/WriterResponseDto.java
@@ -2,18 +2,19 @@ package com.example.schedulee.dto;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 import java.time.LocalDateTime;
 
-@Getter
 @AllArgsConstructor
+@Getter
+@NoArgsConstructor
 @Setter
-public class ScheduleRequestDto {
-    private String todo;
-    private String writerId;
+public class WriterResponseDto {
+    private Long writerId;
+    private String writerEmail;
+    private String name;
     private LocalDateTime createdAt;
     private LocalDateTime modifiedAt;
-    private String password;
-    private LocalDateTime scheduleDate;
 }

--- a/src/main/java/com/example/schedulee/entitty/Schedule.java
+++ b/src/main/java/com/example/schedulee/entitty/Schedule.java
@@ -18,7 +18,7 @@ public class Schedule {
 
     private String todo;
 
-    private String writer;
+    private String writerId;
 
     private String password;
 

--- a/src/main/java/com/example/schedulee/entitty/Writer.java
+++ b/src/main/java/com/example/schedulee/entitty/Writer.java
@@ -1,0 +1,22 @@
+package com.example.schedulee.entitty;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class Writer {
+
+    private Long writerId;
+    private String writerEmail;
+    private String writerName;
+    private LocalDateTime writerCreatedAt;
+    private LocalDateTime writerModifiedAt;
+
+}

--- a/src/main/java/com/example/schedulee/repository/JdbcTemplateWriterRepository.java
+++ b/src/main/java/com/example/schedulee/repository/JdbcTemplateWriterRepository.java
@@ -1,0 +1,52 @@
+package com.example.schedulee.repository;
+
+
+import com.example.schedulee.dto.SearchedScheduleDto;
+import com.example.schedulee.dto.WriterResponseDto;
+import com.example.schedulee.entitty.Writer;
+import lombok.RequiredArgsConstructor;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.simple.SimpleJdbcInsert;
+import org.springframework.stereotype.Repository;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Repository
+@RequiredArgsConstructor
+public class JdbcTemplateWriterRepository implements WriterRepository {
+    private final JdbcTemplate jdbcTemplate;
+
+    @Override
+    public WriterResponseDto saveWriter(Writer wr) {
+        SimpleJdbcInsert jdbcInsert = new SimpleJdbcInsert(jdbcTemplate)
+                .withTableName("writer") // 테이블 이름
+                .usingGeneratedKeyColumns("writer_id"); // 자동 생성되는 pk명
+
+        Map<String, Object> params = new HashMap<>();
+        params.put("writer_email", wr.getWriterEmail());
+        params.put("writer_name", wr.getWriterName());
+        params.put("writer_created_at", wr.getWriterCreatedAt());
+        params.put("modified", wr.getWriterModifiedAt());
+
+        Number key = jdbcInsert.executeAndReturnKey(new MapSqlParameterSource(params));
+
+
+        return new WriterResponseDto(
+                key.longValue(),
+                wr.getWriterEmail(),
+                wr.getWriterName(),
+                wr.getWriterCreatedAt(),
+                wr.getWriterModifiedAt()
+        );
+    }
+
+
+}
+

--- a/src/main/java/com/example/schedulee/repository/ScheduleRepository.java
+++ b/src/main/java/com/example/schedulee/repository/ScheduleRepository.java
@@ -1,9 +1,6 @@
 package com.example.schedulee.repository;
 
-import com.example.schedulee.dto.ScheduleAllDto;
-import com.example.schedulee.dto.ScheduleEditRequestDto;
-import com.example.schedulee.dto.ScheduleRequestAllDto;
-import com.example.schedulee.dto.ScheduleResponseDto;
+import com.example.schedulee.dto.*;
 import com.example.schedulee.entitty.Schedule;
 import org.springframework.stereotype.Repository;
 
@@ -16,11 +13,14 @@ public interface ScheduleRepository {
 
     List<ScheduleAllDto> findByNameOrCreatedAt(ScheduleRequestAllDto sc);
 
-    ScheduleResponseDto findById(Long id);
-
     void updateSchedule(ScheduleEditRequestDto dto, Long id);
 
     Schedule findByScheduleId(Long id);
 
     void deleteById(Long id);
+
+    List<SearchedScheduleDto> findScheduleByID(Long id);
+
+    SearchedScheduleDto findById(Long id);
+
 }

--- a/src/main/java/com/example/schedulee/repository/WriterRepository.java
+++ b/src/main/java/com/example/schedulee/repository/WriterRepository.java
@@ -1,0 +1,13 @@
+package com.example.schedulee.repository;
+
+import com.example.schedulee.dto.SearchedScheduleDto;
+import com.example.schedulee.dto.WriterRegisterRequestDto;
+import com.example.schedulee.dto.WriterResponseDto;
+import com.example.schedulee.entitty.Writer;
+
+import java.util.List;
+
+public interface WriterRepository {
+
+    WriterResponseDto saveWriter(Writer writer);
+}

--- a/src/main/java/com/example/schedulee/service/ScheduleService.java
+++ b/src/main/java/com/example/schedulee/service/ScheduleService.java
@@ -11,9 +11,9 @@ public interface ScheduleService {
 
     List<ScheduleAllDto> searchAll(ScheduleRequestAllDto sc);
 
-    ScheduleResponseDto searchSchedule(Long id);
+    SearchedScheduleDto editInfo(ScheduleEditRequestDto dto, Long id);
 
-    ScheduleResponseDto editInfo(ScheduleEditRequestDto dto, Long id);
+    void deleteSchedule(ScheduleDeleteRequestDto dto);
 
-    void deleteSchedule(Long id);
+    List<SearchedScheduleDto> searchSchedule(Long id);
 }

--- a/src/main/java/com/example/schedulee/service/ScheduleServiceImpl.java
+++ b/src/main/java/com/example/schedulee/service/ScheduleServiceImpl.java
@@ -15,8 +15,6 @@ import java.util.List;
 public class ScheduleServiceImpl implements ScheduleService {
 
     private final ScheduleRepository scheduleRepository;
-    private final JdbcTemplate jdbcTemplate;
-
 
     @Override
     public ScheduleResponseDto postSchedule(ScheduleRequestDto dto) {
@@ -25,7 +23,7 @@ public class ScheduleServiceImpl implements ScheduleService {
             dto.setModifiedAt(LocalDateTime.now());
         }
 
-        Schedule sc = new Schedule(null, dto.getTodo(),dto.getWriter(),dto.getPassword(),dto.getScheduleDate(),dto.getCreatedAt(),dto.getModifiedAt());
+        Schedule sc = new Schedule(null, dto.getTodo(),dto.getWriterId(),dto.getPassword(),dto.getScheduleDate(),dto.getCreatedAt(),dto.getModifiedAt());
         return scheduleRepository.saveSchedule(sc);
     }
 
@@ -37,15 +35,9 @@ public class ScheduleServiceImpl implements ScheduleService {
 
     }
 
-    @Override
-    public ScheduleResponseDto searchSchedule(Long id) {
-
-        ScheduleResponseDto selectedResult = scheduleRepository.findById(id);
-        return selectedResult;
-    }
 
     @Override
-    public ScheduleResponseDto editInfo(ScheduleEditRequestDto dto, Long id) {
+    public SearchedScheduleDto editInfo(ScheduleEditRequestDto dto, Long id) {
 
         // 수정 요청을 받은 DTO의 비밀번호와 DB에 저장된 비밀번호를 비교하기 위해,
         // PathVariable로 전달된 id를 사용하여 DB에서 해당 일정 정보를 조회하고 임시 변수에 할당
@@ -55,11 +47,10 @@ public class ScheduleServiceImpl implements ScheduleService {
         if (schedule.getPassword().equals(dto.getPassword())) {
             scheduleRepository.updateSchedule(dto, id);
 
-            // 업데이트된 정보 다시 조회
-            Schedule updatedSchedule = scheduleRepository.findByScheduleId(id);
+            // 업데이트된 정보를 dto에 담아 반환
+            SearchedScheduleDto updatedSchedule = scheduleRepository.findById(id);
 
-            // 업데이트된 Schedule을 DTO로 변환하여 반환
-            return new ScheduleResponseDto(updatedSchedule);
+            return updatedSchedule;
         } else {
             // 비밀번호가 다르면 사용자에게 알림 처리
             throw new IllegalArgumentException("비밀번호가 일치하지 않습니다.");
@@ -67,18 +58,24 @@ public class ScheduleServiceImpl implements ScheduleService {
     }
 
     @Override
-    public void deleteSchedule(Long id) {
+    public void deleteSchedule(ScheduleDeleteRequestDto dto) {
         // 삭제 요청을 받은 DTO의 비밀번호와 DB에 저장된 비밀번호를 비교하기 위해,
-        // PathVariable로 전달된 id를 사용하여 DB에서 해당 일정 정보를 조회하고 임시 변수에 할당
-        Schedule schedule = scheduleRepository.findByScheduleId(id);
+        // PathVariable로 전달된 Dto에 id를 사용하여 DB에서 해당 일정 정보를 조회하고 임시 변수에 할당
+        Schedule schedule = scheduleRepository.findByScheduleId(dto.getId());
 
         // 조건문을 통해 비밀번호 비교 후 같으면 수정 다르면 예외를 발생시킨다.
-        if (schedule.getPassword().equals(id)) {
-            scheduleRepository.deleteById(id);
+        if (schedule.getPassword().equals(dto.getPassword())) {
+            scheduleRepository.deleteById(dto.getId());
         } else {
             // 비밀번호가 다르면 사용자에게 알림 처리
             throw new IllegalArgumentException("비밀번호가 일치하지 않습니다.");
         }
+    }
+
+    @Override
+    public List<SearchedScheduleDto> searchSchedule(Long id) {
+        List<SearchedScheduleDto> result = scheduleRepository.findScheduleByID(id);
+        return result;
     }
 
 

--- a/src/main/java/com/example/schedulee/service/WriterService.java
+++ b/src/main/java/com/example/schedulee/service/WriterService.java
@@ -1,0 +1,12 @@
+package com.example.schedulee.service;
+
+import com.example.schedulee.dto.SearchedScheduleDto;
+import com.example.schedulee.dto.WriterRegisterRequestDto;
+import com.example.schedulee.dto.WriterResponseDto;
+
+import java.util.List;
+
+public interface WriterService {
+    WriterResponseDto register(WriterRegisterRequestDto dto);
+
+}

--- a/src/main/java/com/example/schedulee/service/WriterServiceImpl.java
+++ b/src/main/java/com/example/schedulee/service/WriterServiceImpl.java
@@ -1,0 +1,32 @@
+package com.example.schedulee.service;
+
+import com.example.schedulee.dto.SearchedScheduleDto;
+import com.example.schedulee.dto.WriterRegisterRequestDto;
+import com.example.schedulee.dto.WriterResponseDto;
+import com.example.schedulee.entitty.Writer;
+import com.example.schedulee.repository.WriterRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class WriterServiceImpl implements WriterService {
+
+    private final WriterRepository writerRepository;
+
+    @Override
+    public WriterResponseDto register(WriterRegisterRequestDto dto) {
+        if (dto.getCreatedAt() == null && dto.getModifiedAt() == null) {
+            dto.setCreatedAt(LocalDateTime.now());
+            dto.setModifiedAt(LocalDateTime.now());
+        }
+        Writer writer = new Writer(null,dto.getEmail(),dto.getName(),dto.getCreatedAt(),dto.getModifiedAt());
+
+        WriterResponseDto registeredWriter = writerRepository.saveWriter(writer);
+        return registeredWriter;
+    }
+
+}


### PR DESCRIPTION
- 작성자 테이블() 생성 및 , ,  필드 추가
- 일정 테이블()에서 를 FK로 설정하여 연관관계 설정
- 일정 조회 시 작성자의 고유 식별자를 기준으로 검색 가능하도록 코드 수정
- 기존 을 직접 사용하던 로직을  기반 조회로 변경