### PR TITLE
feat: 일정 목록 페이지네이션 구현

### DIFF
--- a/src/main/java/com/example/schedulee/controller/ScheduleController.java
+++ b/src/main/java/com/example/schedulee/controller/ScheduleController.java
@@ -8,6 +8,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @RestController
@@ -29,12 +30,17 @@ public class ScheduleController {
     }
 
     // 수정일과 작성자가 일치하는 스케줄 응답
-    @GetMapping ("/all")
-    public ResponseEntity<List<ScheduleAllDto>> getAllSchedule(@RequestBody
-                                                                     ScheduleRequestAllDto sc){
-        List <ScheduleAllDto> getAllInfo = scheduleService.searchAll(sc);
+    @GetMapping("/all")
+    public ResponseEntity<Paging<ScheduleAllDto>> getAllSchedule(
+            @RequestParam String writerName,
+            @RequestParam LocalDateTime modifiedAt,
+            @RequestParam(defaultValue = "1") int page,
+            @RequestParam(defaultValue = "10") int size) {
 
-        return new ResponseEntity<>(getAllInfo,HttpStatus.OK);
+        ScheduleRequestAllDto requestDto = new ScheduleRequestAllDto(writerName, modifiedAt);
+        Paging<ScheduleAllDto> result = scheduleService.searchAllWithPaging(requestDto, page, size);
+
+        return ResponseEntity.ok(result);
     }
 
     @GetMapping("/{id}")

--- a/src/main/java/com/example/schedulee/dto/Paging.java
+++ b/src/main/java/com/example/schedulee/dto/Paging.java
@@ -1,0 +1,18 @@
+package com.example.schedulee.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class Paging<T> {
+
+    private final List<T> content; // 현재 페이지 데이터
+    private final int page; // 현재 페이지 번호
+    private final int size; // 페이지 크기
+    private final long totalElements; // 전체 데이터 개수
+    private final int totalPages; // 전체 페이지 개수
+
+}

--- a/src/main/java/com/example/schedulee/dto/ScheduleRequestAllDto.java
+++ b/src/main/java/com/example/schedulee/dto/ScheduleRequestAllDto.java
@@ -12,5 +12,5 @@ import java.time.LocalDateTime;
 @AllArgsConstructor
 public class ScheduleRequestAllDto {
     private String writerName;
-    private LocalDate modifiedAt;
+    private LocalDateTime modifiedAt;
 }

--- a/src/main/java/com/example/schedulee/service/ScheduleService.java
+++ b/src/main/java/com/example/schedulee/service/ScheduleService.java
@@ -9,7 +9,7 @@ public interface ScheduleService {
 
     ScheduleResponseDto postSchedule(ScheduleRequestDto dto);
 
-    List<ScheduleAllDto> searchAll(ScheduleRequestAllDto sc);
+    Paging<ScheduleAllDto> searchAllWithPaging(ScheduleRequestAllDto sc, int page, int size);
 
     SearchedScheduleDto editInfo(ScheduleEditRequestDto dto, Long id);
 


### PR DESCRIPTION
- 페이지 번호와 크기를 기준으로 일정 목록 조회 기능 구현
- 작성자 이름을 포함한 일정 목록 반환
- 범위를 넘어선 페이지 요청 시 빈 배열 반환
- Paging 객체를 활용하여 페이지네이션 처리