### PR TITLE
feat: 유효성 검사 추가 및 기존 로직 일부 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,20 +18,26 @@ repositories {
 }
 
 dependencies {
+    // Spring Boot 기본 웹 의존성
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+
+    // 데이터베이스 의존성 (필요에 따라 추가)
     implementation 'org.springframework.boot:spring-boot-starter-data-jdbc'
     implementation 'org.springframework.boot:spring-boot-starter-jdbc'
-    implementation 'org.springframework.boot:spring-boot-starter-web'
-    runtimeOnly 'com.mysql:mysql-connector-j'
-    testImplementation 'org.springframework.boot:spring-boot-starter-test'
-    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
-    // MySQL
-    implementation 'mysql:mysql-connector-java:8.0.28'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+    // implementation 'org.hibernate.validator:hibernate-validator:6.2.0.Final'
 
+    // Lombok (컴파일 시 코드 생성)
     implementation 'org.projectlombok:lombok:1.18.24'
     annotationProcessor 'org.projectlombok:lombok:1.18.24'
 
+    // MySQL 의존성
+    runtimeOnly 'com.mysql:mysql-connector-j'
 
+    // 테스트 의존성
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/example/schedulee/controller/ScheduleController.java
+++ b/src/main/java/com/example/schedulee/controller/ScheduleController.java
@@ -2,6 +2,7 @@ package com.example.schedulee.controller;
 
 import com.example.schedulee.dto.*;
 import com.example.schedulee.service.ScheduleService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -22,7 +23,7 @@ public class ScheduleController {
     // 상품 등록
     @PostMapping // 상품 등록 컨트롤러
     public ResponseEntity<ScheduleResponseDto> postingSchedule(
-            @RequestBody ScheduleRequestDto dto
+            @Valid @RequestBody ScheduleRequestDto dto
             ){
         ScheduleResponseDto postedSchedule = scheduleService.postSchedule(dto);
 
@@ -54,7 +55,7 @@ public class ScheduleController {
 
     // 스케줄 수정
     @PatchMapping("/{id}")
-    public ResponseEntity<SearchedScheduleDto> editInfo(@RequestBody ScheduleEditRequestDto dto,
+    public ResponseEntity<SearchedScheduleDto> editInfo(@Valid @RequestBody ScheduleEditRequestDto dto,
     @PathVariable Long id){
 
         SearchedScheduleDto editedSchedule = scheduleService.editInfo(dto,id);
@@ -63,7 +64,7 @@ public class ScheduleController {
 
     // 스케줄 삭제
     @DeleteMapping()
-    public ResponseEntity<String> deleteSchedule(@RequestBody ScheduleDeleteRequestDto dto){
+    public ResponseEntity<String> deleteSchedule(@Valid @RequestBody ScheduleDeleteRequestDto dto){
 
         scheduleService.deleteSchedule(dto);
 

--- a/src/main/java/com/example/schedulee/controller/WriterController.java
+++ b/src/main/java/com/example/schedulee/controller/WriterController.java
@@ -1,16 +1,15 @@
 package com.example.schedulee.controller;
 
-import com.example.schedulee.dto.SearchedScheduleDto;
+
 import com.example.schedulee.dto.WriterRegisterRequestDto;
 import com.example.schedulee.dto.WriterResponseDto;
 import com.example.schedulee.service.WriterService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-
-import java.util.List;
 
 @RestController
 @RequestMapping("/api/writer")
@@ -23,7 +22,7 @@ public class WriterController {
 
     @PostMapping
     public ResponseEntity<WriterResponseDto> register(
-            @RequestBody WriterRegisterRequestDto dto
+            @Valid @RequestBody WriterRegisterRequestDto dto
     ){
         WriterResponseDto registeredWriter = writerService.register(dto);
         return new ResponseEntity<>(registeredWriter, HttpStatus.CREATED);

--- a/src/main/java/com/example/schedulee/dto/ScheduleAllDto.java
+++ b/src/main/java/com/example/schedulee/dto/ScheduleAllDto.java
@@ -1,13 +1,16 @@
 package com.example.schedulee.dto;
 
+
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+
 
 import java.time.LocalDateTime;
 
 @Getter
 @AllArgsConstructor
 public class ScheduleAllDto {
+
     private Long scheduleId;
 
     private String todo;

--- a/src/main/java/com/example/schedulee/dto/ScheduleDeleteRequestDto.java
+++ b/src/main/java/com/example/schedulee/dto/ScheduleDeleteRequestDto.java
@@ -1,12 +1,23 @@
 package com.example.schedulee.dto;
 
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+
+
 
 @Getter
 @AllArgsConstructor
 public class ScheduleDeleteRequestDto {
+    @NotBlank(message = "스케줄 아이디는 필수로 입력해 주셔야 합니다.")
     private Long id;
+
+    @NotBlank(message = "비밀번호는 필수로 입력해 주셔야 합니다.")
+    @Size(min = 8, message = "비밀번호는 최소 8자 이상이어야 합니다.")
+    @Pattern(regexp = ".*[!@#$%^&*(),.?\\\":{}|<>].*", message = "비밀번호는 특수문자를 하나 이상 포함해야 합니다.")
     private String password;
 }
 

--- a/src/main/java/com/example/schedulee/dto/ScheduleEditRequestDto.java
+++ b/src/main/java/com/example/schedulee/dto/ScheduleEditRequestDto.java
@@ -1,14 +1,31 @@
 package com.example.schedulee.dto;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+import jakarta.annotation.Nullable;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.Setter;
 
+
+
 @Getter
 @AllArgsConstructor
 @Setter
+@JsonInclude(JsonInclude.Include.NON_NULL) // null인 값은 직렬화하지 않음
 public class ScheduleEditRequestDto {
+
+    @Nullable
+    @Size(max = 200, message = "할일은 200자 이내로 입력해주세요.")
     String todo;
+
+    @Nullable
     String writerName;
+
+    @NotBlank(message = "비밀번호는 필수로 입력해 주셔야 합니다.")
+    @Size(min = 8, message = "비밀번호는 최소 8자 이상이어야 합니다.")
+    @Pattern(regexp = ".*[!@#$%^&*(),.?\\\":{}|<>].*", message = "비밀번호는 특수문자를 하나 이상 포함해야 합니다.")
     String password; // 수정을 하기 위해 필요한 비밀번호
 }

--- a/src/main/java/com/example/schedulee/dto/ScheduleRequestAllDto.java
+++ b/src/main/java/com/example/schedulee/dto/ScheduleRequestAllDto.java
@@ -1,16 +1,20 @@
 package com.example.schedulee.dto;
 
+import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.Setter;
 
-import java.time.LocalDate;
+
 import java.time.LocalDateTime;
 
 @Getter
 @Setter
 @AllArgsConstructor
 public class ScheduleRequestAllDto {
+    @NotBlank(message = "작성자 이름은 필수로 입력해 주셔야 합니다.")
     private String writerName;
+
+    @NotBlank(message = "수정일시는 필수로 필수로 입력해 주셔야 합니다.")
     private LocalDateTime modifiedAt;
 }

--- a/src/main/java/com/example/schedulee/dto/ScheduleRequestDto.java
+++ b/src/main/java/com/example/schedulee/dto/ScheduleRequestDto.java
@@ -1,8 +1,12 @@
 package com.example.schedulee.dto;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.Setter;
+
 
 import java.time.LocalDateTime;
 
@@ -10,10 +14,20 @@ import java.time.LocalDateTime;
 @AllArgsConstructor
 @Setter
 public class ScheduleRequestDto {
+    @NotBlank(message = "Todo는 필수로 입력해 주셔야 합니다.")
+    @Size(max = 200, message = "할일은 200자 이내로 입력해주세요.")
     private String todo;
+
+    @NotBlank(message = "작성자 아이디는 필수로 입력해 주셔야 합니다.")
     private String writerId;
+
     private LocalDateTime createdAt;
     private LocalDateTime modifiedAt;
+
+    @NotBlank(message = "비밀번호는 필수로 입력해 주셔야 합니다.")
+    @Size(min = 8, message = "비밀번호는 최소 8자 이상(영문자 + 특수문자 1개 이상)이어야 합니다.")
+    @Pattern(regexp = ".*[!@#$%^&*(),.?\\\":{}|<>].*", message = "비밀번호는 특수문자를 하나 이상 포함해야 합니다.")
     private String password;
+
     private LocalDateTime scheduleDate;
 }

--- a/src/main/java/com/example/schedulee/dto/WriterRegisterRequestDto.java
+++ b/src/main/java/com/example/schedulee/dto/WriterRegisterRequestDto.java
@@ -1,8 +1,11 @@
 package com.example.schedulee.dto;
 
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.Setter;
+
 
 import java.time.LocalDateTime;
 
@@ -10,8 +13,13 @@ import java.time.LocalDateTime;
 @AllArgsConstructor
 @Setter
 public class WriterRegisterRequestDto {
+    @NotBlank(message = "이메일을 필수로 입력해 주셔야 합니다.")
+    @Email(message = "이메일 형식에 맞게 입력해 주세요.")
     private String email;
+
+    @NotBlank(message = "이름은 필수로 입력해 주셔야 합니다.")
     private String name;
+
     private LocalDateTime createdAt;
     private LocalDateTime modifiedAt;
 }

--- a/src/main/java/com/example/schedulee/exception/ErrorCode.java
+++ b/src/main/java/com/example/schedulee/exception/ErrorCode.java
@@ -7,18 +7,11 @@ import org.springframework.http.HttpStatus;
 @Getter
 @RequiredArgsConstructor
 public enum ErrorCode {
-    // 이메일
-    INVALID_EMAIL(HttpStatus.BAD_REQUEST, "잘못된 이메일 형식입니다."),
 
     // 사용자
     USER_NOT_FOUND(HttpStatus.NOT_FOUND,"유저를 찾을 수 없습니다."),
-    OVER_LIMITED_SIZE(HttpStatus.BAD_REQUEST,"Todo는 최대 200자까지 작성가능합니다."),
-    INVALID_ID(HttpStatus.BAD_REQUEST, "잘못된 이메일 형식입니다."),
-
-
-    // 비밀번호
-    INVALID_PASSWORD(HttpStatus.BAD_REQUEST, "비밀번호는 8~20자, 영문 대소문자 중 하나와 숫자를 포함해야 합니다."),
-    PASSWORD_NOT_MATCH(HttpStatus.FORBIDDEN,"비밀번호가 일치하지 않습니다."),
+    INVALID_ID(HttpStatus.BAD_REQUEST, "Id값이 null 입니다."),
+    PASSWORD_NOT_MATCH(HttpStatus.BAD_REQUEST,"비밀번호가 일치하지 않습니다."),
 
     // 스케줄
     SCHEDULE_NOT_FOUND(HttpStatus.NOT_FOUND,"일치하는 스케줄이 없습니다.");

--- a/src/main/java/com/example/schedulee/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/schedulee/exception/GlobalExceptionHandler.java
@@ -1,13 +1,36 @@
 package com.example.schedulee.exception;
 
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.context.request.WebRequest;
+
+import java.util.HashMap;
+import java.util.Map;
 
 @Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler {
+
+    // 유효성 검사 실패 예외 처리
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<Object> handleValidationExceptions(MethodArgumentNotValidException ex, WebRequest request) {
+        Map<String, String> errors = new HashMap<>();
+
+        // 각 필드에 대한 오류 메시지를 가져옴
+        ex.getBindingResult().getAllErrors().forEach(error -> {
+            String fieldName = ((FieldError) error).getField();
+            String message = error.getDefaultMessage();
+            errors.put(fieldName, message);
+        });
+
+        return new ResponseEntity<>(errors, HttpStatus.BAD_REQUEST);
+    }
+
 
     @ExceptionHandler(CustomException.class)
     public ResponseEntity<String> handleCustomException(CustomException ex) {

--- a/src/main/java/com/example/schedulee/repository/JdbcTemplateScheduleRepository.java
+++ b/src/main/java/com/example/schedulee/repository/JdbcTemplateScheduleRepository.java
@@ -69,25 +69,22 @@ public class JdbcTemplateScheduleRepository implements ScheduleRepository{
     }
 
 
-
-
-    @Override
-    public void updateSchedule(ScheduleEditRequestDto dto, Long id) {
-        LocalDateTime now = LocalDateTime.now(); // 현재 시간
-
-        // 1. 작성자 이름을 writer 테이블에서 업데이트
-        jdbcTemplate.update(
-                "UPDATE writer SET writer_name = ?, writer_modified_at = ? WHERE writer_id = (SELECT writer_id FROM schedule WHERE schedule_id = ?)",
-                dto.getWriterName(),
-                now,
-                id
-        );
-
-        // 2. schedule 테이블에서 todo와 modified_at 업데이트
+    // schedule 테이블에서 todo와 modified_at 업데이트
+    public void updateScheduleTodo(String todo, Long id) {
         jdbcTemplate.update(
                 "UPDATE schedule SET todo = ?, modified_at = ? WHERE schedule_id = ?",
-                dto.getTodo(),
-                now,
+                todo,
+                LocalDateTime.now(), // 수정된 시간
+                id
+        );
+    }
+
+    // writer 테이블에서 writer_name과 writer_modified_at 업데이트
+    public void updateWriterName(String writerName, Long id) {
+        jdbcTemplate.update(
+                "UPDATE writer SET writer_name = ?, writer_modified_at = ? WHERE writer_id = (SELECT writer_id FROM schedule WHERE schedule_id = ?)",
+                writerName,
+                LocalDateTime.now(), // 수정된 시간
                 id
         );
     }

--- a/src/main/java/com/example/schedulee/repository/ScheduleRepository.java
+++ b/src/main/java/com/example/schedulee/repository/ScheduleRepository.java
@@ -14,8 +14,6 @@ public interface ScheduleRepository {
 
     List<ScheduleAllDto> findByNameOrCreatedAt(ScheduleRequestAllDto sc);
 
-    void updateSchedule(ScheduleEditRequestDto dto, Long id);
-
     Optional<Schedule> findByScheduleId(Long id);
 
     void deleteById(Long id);
@@ -23,5 +21,9 @@ public interface ScheduleRepository {
     Optional<List<SearchedScheduleDto>> findScheduleByID(Long id);
 
     SearchedScheduleDto findById(Long id);
+
+    void updateScheduleTodo(String todo, Long id);
+
+    void updateWriterName(String writerName, Long id);
 
 }

--- a/src/main/java/com/example/schedulee/service/ScheduleServiceImpl.java
+++ b/src/main/java/com/example/schedulee/service/ScheduleServiceImpl.java
@@ -68,7 +68,6 @@ public class ScheduleServiceImpl implements ScheduleService {
         if (id == null) {
             throw new CustomException(ErrorCode.INVALID_ID);
         }
-
         // 수정 요청을 받은 DTO의 비밀번호와 DB에 저장된 비밀번호를 비교하기 위해,
         // PathVariable로 전달된 id를 사용하여 DB에서 해당 일정 정보를 조회하고 임시 변수에 할당
         Schedule schedule = scheduleRepository.findByScheduleId(id)
@@ -76,7 +75,19 @@ public class ScheduleServiceImpl implements ScheduleService {
 
         // 조건문을 통해 비밀번호 비교 후 같으면 수정 다르면 예외를 발생시킨다.
         if (schedule.getPassword().equals(dto.getPassword())) {
-            scheduleRepository.updateSchedule(dto, id);
+
+
+            // 비밀번호 외 다른 수정 항목을 업데이트하는 부분
+            if (dto.getWriterName() != null) {
+                // 작성자 이름이 null이 아니면 writer 테이블에서 수정
+                scheduleRepository.updateWriterName(dto.getWriterName(), id);
+            }
+            if (dto.getTodo() != null) {
+                // 할 일(todo)이 null이 아니면 schedule 테이블에서 수정
+                scheduleRepository.updateScheduleTodo(dto.getTodo(), id);
+            }
+
+
 
             // 업데이트된 정보를 dto에 담아 반환
             SearchedScheduleDto updatedSchedule = scheduleRepository.findById(id);


### PR DESCRIPTION
- 할일은 최대 200자 이내로 제한, 필수값 처리
- 비밀번호는 필수값 처리
- 담당자의 이메일 정보가 형식에 맞는지 확인
- 작성자 이름과 Todo 수정시 둘 중 수정원하는 값만 body에 포함해서 보내도록 수정
- 쓰지 않는 예외 처리 및 유효성 검사 예외처리 로직 추가